### PR TITLE
Code Server 4.8.3 Build #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,28 +4,9 @@ USER root
 
 # apt packages
 RUN apt-get update \
- && apt-get install -y apt-transport-https gnupg \
- && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null \
- && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ buster main" > /etc/apt/sources.list.d/azure-cli.list \
- && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - \
- && echo "deb https://deb.nodesource.com/node_18.x buster main" >> /etc/apt/sources.list.d/nodesource.list \
- && echo "deb-src https://deb.nodesource.com/node_18.x buster main" >> /etc/apt/sources.list.d/nodesource.list \
- && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" >> /etc/apt/sources.list.d/google-cloud-sdk.list \
- && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
- && apt-get update \
- && apt-get install -y unzip zsh nodejs uidmap build-essential sqlite3 libsqlite3-dev vim azure-cli google-cloud-cli \
+ && apt-get install -y curl ca-certificates uidmap build-essential \
  && apt-get upgrade -y \
  && rm -rf /var/lib/apt/lists/*
-
-# serverless
-RUN npm install -g serverless
-
-# ngrok
-RUN curl -Lo /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip \
- && cd /tmp \
- && unzip /tmp/ngrok.zip \
- && mv ngrok /usr/local/bin/ngrok \
- && rm /tmp/ngrok.zip
 
 # go
 RUN curl -Lo /tmp/go.tar.gz https://dl.google.com/go/go1.19.3.linux-amd64.tar.gz \
@@ -33,107 +14,14 @@ RUN curl -Lo /tmp/go.tar.gz https://dl.google.com/go/go1.19.3.linux-amd64.tar.gz
  && rm /tmp/go.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
-# docker (CLI only)
-RUN curl -Lo /tmp/docker.tar.gz https://download.docker.com/linux/static/stable/x86_64/docker-20.10.2.tgz \
- && cd /tmp \
- && tar -xzf /tmp/docker.tar.gz \
- && mv /tmp/docker/docker /usr/local/bin/docker \
- && rm -rf /tmp/docker /tmp/docker.tar.gz
-
-# docker-compose
-RUN curl -Lo /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 \
- && chmod +x /usr/local/bin/docker-compose
-
 # kubectl
 RUN curl -Lo /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl \
  && chmod +x /tmp/kubectl \
  && mv /tmp/kubectl /usr/local/bin/kubectl
 ENV KUBE_EDITOR=vim
 
-# kubeadm
-RUN curl -Lo /tmp/kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubeadm \
- && chmod +x /tmp/kubeadm \
- && mv /tmp/kubeadm /usr/local/bin/kubeadm
-
-# helm2
-RUN curl -Lo /tmp/helm.tar.gz https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz \
- && cd /tmp \
- && tar -xzf helm.tar.gz \
- && mv /tmp/linux-amd64/helm /usr/local/bin/helm2 \
- && rm -rf /tmp/linux-amd64 /tmp/helm.tar.gz
-
-# helm
-RUN curl -Lo /tmp/helm.tar.gz https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz \
- && cd /tmp \
- && tar -xzf helm.tar.gz \
- && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
- && rm -rf /tmp/linux-amd64 /tmp/helm.tar.gz
-
-# skaffold
-RUN curl -Lo /usr/local/bin/skaffold https://storage.googleapis.com/skaffold/releases/v1.39.1/skaffold-linux-amd64 \
- && chmod a+x /usr/local/bin/skaffold
-
-# kustomize
-RUN curl -Lo /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.4/kustomize_v4.5.4_linux_amd64.tar.gz \
- && cd /tmp \
- && tar -xzf kustomize.tar.gz \
- && mv /tmp/kustomize /usr/local/bin/kustomize \
- && rm -rf /tmp/kustomize.tar.gz 
-
-# img
-RUN curl -fSL "https://github.com/genuinetools/img/releases/download/v0.5.11/img-linux-amd64" -o "/usr/local/bin/img" \
- && chmod a+x "/usr/local/bin/img"
-
-# ctr (containerd CLI)
-RUN curl -Lo /tmp/ctr.tar.gz https://github.com/containerd/containerd/releases/download/v1.3.7/containerd-1.3.7-linux-amd64.tar.gz \
- && cd /tmp \
- && tar -xzf ctr.tar.gz \
- && mv /tmp/bin/ctr /usr/local/bin/ctr \
- && rm -rf /tmp/bin /tmp/ctr.tar.gz 
-
-# rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.52 -c rls -y
-
-# fluxcd2 0.14.2
-RUN curl -Lo /tmp/flux.tar.gz https://github.com/fluxcd/flux2/releases/download/v0.14.2/flux_0.14.2_linux_amd64.tar.gz \
- && cd /tmp \
- && tar -xzf flux.tar.gz \
- && mv /tmp/flux /usr/local/bin/flux14 \
- && rm -rf /tmp/flux /tmp/flux.tar.gz
-
-# fluxcd2 0.29.5
-RUN curl -Lo /tmp/flux.tar.gz https://github.com/fluxcd/flux2/releases/download/v0.29.5/flux_0.29.5_linux_amd64.tar.gz \
- && cd /tmp \
- && tar -xzf flux.tar.gz \
- && mv /tmp/flux /usr/local/bin/flux \
- && rm -rf /tmp/flux /tmp/flux.tar.gz
- 
- # k3s
-RUN curl -fSL "https://github.com/k3s-io/k3s/releases/download/v1.23.6%2Bk3s1/k3s" -o "/usr/local/bin/k3s" \
- && chmod a+x "/usr/local/bin/k3s"
-
-# aws v2
-# release list: https://github.com/aws/aws-cli/tags
-RUN curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.7.29.zip" -o "/tmp/awscliv2.zip" \
- && cd /tmp \
- && unzip awscliv2.zip \
- && ./aws/install \
- && rm -rf /tmp/aws /tmp/awscliv2.zip
-
-# terraform
-# release list: https://github.com/hashicorp/terraform/releases
-RUN curl -L "https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_linux_amd64.zip" -o "/tmp/terraform.zip" \
- && cd /tmp \
- && unzip terraform.zip \
- && mv /tmp/terraform /usr/local/bin/terraform \
- && rm -rf /tmp/terraform.zip
-
-# nats - NATS CLI
-# release list: https://github.com/nats-io/natscli/releases
-RUN curl -L "https://github.com/nats-io/natscli/releases/download/v0.0.33/nats-0.0.33-linux-amd64.zip" -o "/tmp/nats.zip" \
- && cd /tmp \
- && unzip nats.zip \
- && mv /tmp/nats-0.0.33-linux-amd64/nats /usr/local/bin/nats \
- && rm -rf /tmp/nats-0.0.33-linux-amd64 /tmp/nats.zip
+# install-scripts
+COPY install-scripts/ /usr/local/installable/
+ENV PATH=$PATH:/usr/local/installable
 
 USER coder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codercom/code-server:4.7.0
+FROM codercom/code-server:4.8.3-focal
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -Lo /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-li
  && rm /tmp/ngrok.zip
 
 # go
-RUN curl -Lo /tmp/go.tar.gz https://dl.google.com/go/go1.19.1.linux-amd64.tar.gz \
+RUN curl -Lo /tmp/go.tar.gz https://dl.google.com/go/go1.19.3.linux-amd64.tar.gz \
  && tar -C /usr/local -xzf /tmp/go.tar.gz \
  && rm /tmp/go.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin

--- a/install-scripts/aws
+++ b/install-scripts/aws
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/aws" ]
+then
+    echo "aws is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.7.29.zip" -o "/tmp/aws.zip"
+    pushd /tmp
+    unzip aws.zip
+    sudo ./aws/install
+    rm -rf /tmp/aws /tmp/aws.zip
+    popd
+    exec /usr/local/bin/aws $@
+else
+    exec /usr/local/bin/aws $@
+fi

--- a/install-scripts/az
+++ b/install-scripts/az
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ ! -f "/usr/bin/az" ]
+then
+    echo "az is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo apt-get update
+    sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+    AZ_REPO=$(lsb_release -cs)
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+    sudo apt-get update
+    sudo apt-get install -y azure-cli
+    exec /usr/bin/az $@
+else
+    exec /usr/bin/az $@
+fi

--- a/install-scripts/cargo
+++ b/install-scripts/cargo
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ ! -f "$HOME/.cargo/bin/cargo" ]
+then
+    echo "cargo is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.52 -c rls -y
+    exec $HOME/.cargo/bin/cargo $@
+else
+    exec $HOME/.cargo/bin/cargo $@
+fi

--- a/install-scripts/ctr
+++ b/install-scripts/ctr
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# release list: https://github.com/containerd/containerd/releases
+
+if [ ! -f "/usr/local/bin/ctr" ]
+then
+    echo "ctr is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -L "https://github.com/containerd/containerd/releases/download/v1.3.7/containerd-1.3.7-linux-amd64.tar.gz" -o "/tmp/ctr.tar.gz"
+    pushd /tmp
+    tar -xzf ctr.tar.gz
+    sudo mv /tmp/bin/ctr /usr/local/bin/ctr
+    rm -rf /tmp/bin /tmp/ctr.tar.gz
+    popd
+    exec /usr/local/bin/ctr $@
+else
+    exec /usr/local/bin/ctr $@
+fi

--- a/install-scripts/docker
+++ b/install-scripts/docker
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/docker" ]
+then
+    echo "docker is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -Lo /tmp/docker.tar.gz https://download.docker.com/linux/static/stable/x86_64/docker-20.10.2.tgz
+    pushd /tmp
+    tar -xzf /tmp/docker.tar.gz
+    sudo mv /tmp/docker/docker /usr/local/bin/docker
+    rm -rf /tmp/docker /tmp/docker.tar.gz
+    popd
+    exec /usr/local/bin/docker $@
+else
+    exec /usr/local/bin/docker $@
+fi

--- a/install-scripts/docker-compose
+++ b/install-scripts/docker-compose
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/docker-compose" ]
+then
+    echo "docker-compose is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo curl -Lo /usr/local/bin/docker-compose https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
+    sudo chmod +x /usr/local/bin/docker-compose
+    exec /usr/local/bin/docker-compose $@
+else
+    exec /usr/local/bin/docker-compose $@
+fi

--- a/install-scripts/flux
+++ b/install-scripts/flux
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/flux" ]
+then
+    echo "flux is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -Lo /tmp/flux.tar.gz https://github.com/fluxcd/flux2/releases/download/v0.29.5/flux_0.29.5_linux_amd64.tar.gz
+    pushd /tmp
+    tar -xzf /tmp/flux.tar.gz
+    sudo mv /tmp/flux /usr/local/bin/flux
+    rm -rf /tmp/flux /tmp/flux.tar.gz
+    popd
+    exec /usr/local/bin/flux $@
+else
+    exec /usr/local/bin/flux $@
+fi

--- a/install-scripts/gcloud
+++ b/install-scripts/gcloud
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/bin/gcloud" ]
+then
+    echo "gcloud is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo apt-get update
+    sudo apt-get install -y ca-certificates curl apt-transport-https gnupg
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.gpg
+    sudo apt-get update
+    sudo apt-get install -y google-cloud-cli
+    exec /usr/bin/gcloud $@
+else
+    exec /usr/bin/gcloud $@
+fi

--- a/install-scripts/helm
+++ b/install-scripts/helm
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/helm" ]
+then
+    echo "helm is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -Lo /tmp/helm.tar.gz https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz
+    pushd /tmp
+    tar -xzf /tmp/helm.tar.gz
+    sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
+    rm -rf /tmp/linux-amd64 /tmp/helm.tar.gz
+    popd
+    exec /usr/local/bin/helm $@
+else
+    exec /usr/local/bin/helm $@
+fi

--- a/install-scripts/helm2
+++ b/install-scripts/helm2
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/helm2" ]
+then
+    echo "helm2 is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -Lo /tmp/helm2.tar.gz https://get.helm.sh/helm-v2.17.0-linux-amd64.tar.gz
+    pushd /tmp
+    tar -xzf /tmp/helm2.tar.gz
+    sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm2
+    rm -rf /tmp/linux-amd64 /tmp/helm2.tar.gz
+    popd
+    exec /usr/local/bin/helm2 $@
+else
+    exec /usr/local/bin/helm2 $@
+fi

--- a/install-scripts/img
+++ b/install-scripts/img
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/img" ]
+then
+    echo "img is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo curl -Lo /usr/local/bin/img https://github.com/genuinetools/img/releases/download/v0.5.11/img-linux-amd64
+    sudo chmod a+x "/usr/local/bin/img"
+    exec /usr/local/bin/img $@
+else
+    exec /usr/local/bin/img $@
+fi

--- a/install-scripts/k3s
+++ b/install-scripts/k3s
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/k3s" ]
+then
+    echo "k3s is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo curl -Lo /usr/local/bin/k3s https://github.com/k3s-io/k3s/releases/download/v1.23.6%2Bk3s1/k3s
+    sudo chmod a+x "/usr/local/bin/k3s"
+    exec /usr/local/bin/k3s $@
+else
+    exec /usr/local/bin/k3s $@
+fi

--- a/install-scripts/kubeadm
+++ b/install-scripts/kubeadm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/kubeadm" ]
+then
+    echo "kubeadm is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo curl -Lo /usr/local/bin/kubeadm https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubeadm
+    sudo chmod +x /usr/local/bin/kubeadm
+    exec /usr/local/bin/kubeadm $@
+else
+    exec /usr/local/bin/kubeadm $@
+fi

--- a/install-scripts/kustomize
+++ b/install-scripts/kustomize
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/kustomize" ]
+then
+    echo "kustomize is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -Lo /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.4/kustomize_v4.5.4_linux_amd64.tar.gz
+    pushd /tmp
+    tar -xzf /tmp/kustomize.tar.gz
+    sudo mv /tmp/kustomize /usr/local/bin/kustomize
+    rm -rf /tmp/kustomize.tar.gz
+    popd
+    exec /usr/local/bin/kustomize $@
+else
+    exec /usr/local/bin/kustomize $@
+fi

--- a/install-scripts/nats
+++ b/install-scripts/nats
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/nats" ]
+then
+    echo "nats is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -L "https://github.com/nats-io/natscli/releases/download/v0.0.33/nats-0.0.33-linux-amd64.zip" -o "/tmp/nats.zip" -o "/tmp/nats.zip"
+    pushd /tmp
+    unzip nats.zip
+    sudo mv /tmp/nats-0.0.33-linux-amd64/nats /usr/local/bin/nats
+    rm -rf /tmp/nats-0.0.33-linux-amd64 /tmp/nats.zip
+    popd
+    exec /usr/local/bin/nats $@
+else
+    exec /usr/local/bin/nats $@
+fi

--- a/install-scripts/ngrok
+++ b/install-scripts/ngrok
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/ngrok" ]
+then
+    echo "ngrok is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -Lo /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
+    pushd /tmp
+    unzip /tmp/ngrok.zip
+    sudo mv ngrok /usr/local/bin/ngrok
+    rm /tmp/ngrok.zip
+    popd
+    exec /usr/local/bin/ngrok $@
+else
+    exec /usr/local/bin/ngrok $@
+fi

--- a/install-scripts/node
+++ b/install-scripts/node
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "$HOME/.nvm/versions/node/v18.12.1/bin/node" ]
+then
+    echo "node is not installed. Installing now with nvm... (if prompted, enter password for sudo)"
+    nvm install v18.12.1 --latest-npm
+    nvm use v18.12.1
+    exec $HOME/.nvm/versions/node/v18.12.1/bin/node $@
+else
+    exec $HOME/.nvm/versions/node/v18.12.1/bin/node $@
+fi

--- a/install-scripts/npm
+++ b/install-scripts/npm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "$HOME/.nvm/versions/node/v18.12.1/bin/npm" ]
+then
+    echo "npm is not installed. Installing now with nvm... (if prompted, enter password for sudo)"
+    nvm install v18.12.1 --latest-npm
+    nvm use v18.12.1
+    exec $HOME/.nvm/versions/node/v18.12.1/bin/npm $@
+else
+    exec $HOME/.nvm/versions/node/v18.12.1/bin/npm $@
+fi

--- a/install-scripts/nvm
+++ b/install-scripts/nvm
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ -z "${NVM_DIR}" ]
+then
+    echo "nvm is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
+    source $HOME/.bashrc
+    #We'll also manually load nvm for good measure
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+    nvm $@
+else
+    #Seems like the bashrc is broken, let's try manually loading
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+    nvm $@
+fi

--- a/install-scripts/rustc
+++ b/install-scripts/rustc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ ! -f "$HOME/.cargo/bin/rustc" ]
+then
+    echo "rustc is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.52 -c rls -y
+    exec $HOME/.cargo/bin/rustc $@
+else
+    exec $HOME/.cargo/bin/rustc $@
+fi

--- a/install-scripts/serverless
+++ b/install-scripts/serverless
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ ! -f "$HOME/.nvm/versions/node/v18.12.1/bin/serverless" ]
+then
+    echo "serverless is not installed. Installing now with npm... (if prompted, enter password for sudo)"
+    npm install -g serverless
+    exec $HOME/.nvm/versions/node/v18.12.1/bin/serverless $@
+else
+    exec $HOME/.nvm/versions/node/v18.12.1/bin/serverless $@
+fi

--- a/install-scripts/skaffold
+++ b/install-scripts/skaffold
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/local/bin/skaffold" ]
+then
+    echo "skaffold is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo curl -Lo /usr/local/bin/skaffold https://storage.googleapis.com/skaffold/releases/v1.39.1/skaffold-linux-amd64
+    sudo chmod +x /usr/local/bin/skaffold
+    exec /usr/local/bin/skaffold $@
+else
+    exec /usr/local/bin/skaffold $@
+fi

--- a/install-scripts/sqlite3
+++ b/install-scripts/sqlite3
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/bin/sqlite3" ]
+then
+    echo "sqlite3 is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo apt-get update
+    sudo apt-get install -y sqlite3 libsqlite3-dev
+    exec /usr/bin/sqlite3 $@
+else
+    exec /usr/bin/sqlite3 $@
+fi

--- a/install-scripts/terraform
+++ b/install-scripts/terraform
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# release list: https://github.com/hashicorp/terraform/releases
+
+if [ ! -f "/usr/local/bin/terraform" ]
+then
+    echo "terraform is not installed. Installing now... (if prompted, enter password for sudo)"
+    curl -L "https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_linux_amd64.zip" -o "/tmp/terraform.zip"
+    pushd /tmp
+    unzip terraform.zip
+    sudo mv /tmp/terraform /usr/local/bin/terraform
+    rm -rf /tmp/terraform.zip
+    popd
+    exec /usr/local/bin/terraform $@
+else
+    exec /usr/local/bin/terraform $@
+fi

--- a/install-scripts/unzip
+++ b/install-scripts/unzip
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/bin/unzip" ]
+then
+    echo "unzip is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo apt-get update
+    sudo apt-get install -y unzip
+    exec /usr/bin/unzip $@
+else
+    exec /usr/bin/unzip $@
+fi

--- a/install-scripts/vim
+++ b/install-scripts/vim
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ! -f "/usr/bin/vim" ]
+then
+    echo "vim is not installed. Installing now... (if prompted, enter password for sudo)"
+    sudo apt-get update
+    sudo apt-get install -y vim
+    exec /usr/bin/vim $@
+else
+    exec /usr/bin/vim $@
+fi


### PR DESCRIPTION
- Update Code Server to 4.8.3
- Switch to Ubuntu Focal based images
- Update Golang to 1.19.3
- Move most apps (except Golang and kubectl) to scripts that semi-transparently install the tool

The new bash scripts check if the main command executable is available, and if not then install the tool, then exec it.
If it's already available, it should either be higher in the PATH or the script will exec it.
This gives the experience where if a tools is not installed (e.g. because the container was replaced), then the its installed on the fly, almost transparently to the user.
This saves almost 4GB from the image size!